### PR TITLE
Corrigindo 'ReferenceError' no comando padrão

### DIFF
--- a/commands/padrao.js
+++ b/commands/padrao.js
@@ -7,12 +7,10 @@ exports.default = (client, target, context, message) => {
     return;
   }
   mensagens.push(message);
-  const mensagemSplited = message.split(' ');
 
   if (
     mensagens[mensagens.length - 1] === mensagens[mensagens.length - 2] &&
-    padroesFeitos.indexOf(message) === -1 &&
-    bannedWords.includes(mensagemSplited[0])
+    padroesFeitos.indexOf(message) === -1
   ) {
     padroesFeitos.push(message);
     client.say(target, message);


### PR DESCRIPTION
Corrigindo o problema de referência de variável inexistente quando o bot recebe duas mensagens iguais em sequência:

```
O overlay está rodando em: http://localhost:5050
* Bot entrou no endereço irc-ws.chat.twitch.tv:80
C:\%\pandadomalbot\commands\padrao.js:15
    bannedWords.includes(mensagemSplited[0])
    ^

ReferenceError: bannedWords is not defined
```