### PR TITLE
Corrigindo falha na existência do diretório /data

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -7,7 +7,7 @@
 
 const { Client } = require('tmi.js');
 require('dotenv').config();
-const { readdirSync } = require('fs');
+const { readdirSync, existsSync, mkdirSync } = require('fs');
 const express = require('express');
 const axios = require('axios');
 
@@ -18,6 +18,10 @@ const io = require('socket.io')(http);
 const timer = require('./timers');
 
 const porta = 5050;
+
+if (!existsSync('./data/')) {
+  mkdirSync('./data/', { recursive: true });
+}
 
 app.get('/', (req, res) => {
   res.sendFile(`${__dirname}/src/public/index.html`);


### PR DESCRIPTION
Esse problema acontece quando o bot é executado pela primeira vez (após um clone, por exemplo) onde o diretório `./data` ainda não existe. Quando o bot tenta criar o arquivo `jail.json` no diretório inexistente, o seguinte erro ocorre:

```sh
> npm start

> pandadomalbot@1.0.0 start
> node src/bot.js

O overlay está rodando em: http://localhost:5050
* Bot entrou no endereço irc-ws.chat.twitch.tv:443
Falha ao persistir o conteúdo "{"prisoners":[],"rescuers":[],"fugitives":[],"protected":[],"last_date":"10/03/2021"}" em "./data//jail.json". Err: Error: ENOENT: no such file or directory, open './data//jail.json'
```