### PR TITLE
Refatorando o uso da função `sample`

### DIFF
--- a/src/commands/fun/aposta-lev.js
+++ b/src/commands/fun/aposta-lev.js
@@ -2,6 +2,7 @@ const { levxycas } = require('./_constants');
 const { client } = require('../../core/twitch_client');
 const { people } = require('../../queues/people');
 const { isToday } = require('../../utilities/date-time');
+const { sample } = require('../../utilities/collections');
 
 const COMMAND_KEY = 'apostalev';
 const POINTS = process.env.POINTS_APOSTA_LEV || 150;
@@ -33,7 +34,9 @@ module.exports = {
     }
 
     const choice = argument.split(' ')[0];
-    const selected = levxycas[Math.floor(Math.random() * levxycas.length)];
+    const selected = sample(levxycas);
+
+    if (!selected) return;
 
     await people(context.username, (person) => {
       if (haveUsedTheCommandToday(person)) {

--- a/src/commands/fun/lev.js
+++ b/src/commands/fun/lev.js
@@ -1,10 +1,13 @@
 const { levxycas } = require('./_constants');
 const { client } = require('../../core/twitch_client');
+const { sample } = require('../../utilities/collections');
 
 module.exports = {
   keyword: 'lev',
   async execute({ context, channel }) {
-    const selected = levxycas[Math.floor(Math.random() * levxycas.length)];
+    const selected = sample(levxycas);
+
+    if (!selected) return;
 
     await client.say(
       channel,

--- a/src/commands/jail/escapar.js
+++ b/src/commands/jail/escapar.js
@@ -2,6 +2,7 @@ const { client } = require('../../core/twitch_client');
 const { EscapeActions } = require('../../models/jail');
 const { jail } = require('../../queues/jail');
 const { people } = require('../../queues/people');
+const { sample } = require('../../utilities/collections');
 
 const POINTS_TO_ESCAPE = process.env.POINTS_ESCAPAR_DA_PRISAO.split(',');
 
@@ -20,11 +21,7 @@ module.exports = {
           message = `PunOko ${context.username}, você já tentou escapar.`;
           break;
         case EscapeActions.SUCCESS_TO_ESCAPE: {
-          const points = Number(
-            POINTS_TO_ESCAPE[
-              Math.floor(Math.random() * POINTS_TO_ESCAPE.length)
-            ],
-          );
+          const points = Number(sample(POINTS_TO_ESCAPE));
 
           await people(context.username, (p) => {
             p.points += points;

--- a/src/models/jail.js
+++ b/src/models/jail.js
@@ -1,3 +1,4 @@
+const { sample } = require('../utilities/collections');
 const { read } = require('../utilities/data-file');
 const { usersInChat } = require('../utilities/twitch');
 
@@ -78,7 +79,7 @@ class Jail {
       console.info('Nenhum sub para ser protegido atualmente no chat.');
       return null;
     }
-    const user = subsInChat[Math.floor(Math.random() * subsInChat.length)];
+    const user = sample(subsInChat);
 
     this.users.protected = user;
     console.info('Novo usuário protegido:', user);
@@ -100,7 +101,7 @@ class Jail {
 
     if (chat.length === 0) return null;
 
-    const user = chat[Math.floor(Math.random() * chat.length)];
+    const user = sample(chat);
     this.prisoners.push(user.toLowerCase());
 
     console.info('Novo usuário preso:', user);
@@ -131,8 +132,7 @@ class Jail {
       return RescueActions.ALREADY_TRIED_TO_RESCUE;
 
     if (Math.random() < 0.5) {
-      const rescued =
-        this.prisoners[Math.floor(Math.random() * this.prisoners.length)];
+      const rescued = sample(this.prisoners);
 
       this.prisoners = this.prisoners.filter((u) => u !== rescued);
 

--- a/src/utilities/collections.js
+++ b/src/utilities/collections.js
@@ -1,13 +1,12 @@
 /**
- * Get a sample value from the collection.
+ * Obtém um valor aleatório do Array.
  *
  * @param collection
  * @returns {*}
  */
 function sample(collection) {
-  return collection[Math.floor(Math.random() * collection.length)];
+  const length = collection == null ? 0 : collection.length;
+  return length ? collection[Math.floor(Math.random() * length)] : undefined;
 }
 
-module.exports = {
-  sample,
-};
+module.exports = { sample };


### PR DESCRIPTION
Substituindo o uso de `<array>[Math.floor(Math.random() * <array>.length)]` pela função `sample` criada no PR #242.
Visto que deveria ter o mesmo comportamento da função `sample` do lodash, peguei a implementação daqui:

https://github.com/lodash/lodash/blob/2f79053d7bc7c9c9561a30dda202b3dcd2b72b90/sample.js#L13-L16