### PR TITLE
Exportando comandos do bot

### DIFF
--- a/.github/docs/criando-novos-comandos.md
+++ b/.github/docs/criando-novos-comandos.md
@@ -37,6 +37,22 @@ module.exports = {
 };
 ```
 
+## Exportando comandos
+
+Caso precise exportar todos os comandos (e alias) existentes no bot, pode utilizar o comando:
+
+```sh
+npm run export
+```
+
+Caso queira exportar o JSON formatado, indentado, use a flag `-pretty`:
+
+```sh
+npm run export -- -pretty
+```
+
+Um novo arquivo `commands.json` será criado no diretório raiz do projeto.
+
 ## ✨ Dicas
 
 - A função `execute` não necessiriamente precisa ser uma função. Se um comando não realiza nenhum

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 # Arquivos locais
 .env
 data/*
+commands.json

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "start": "node src/index.js",
     "dev": "nodemon --watch src",
     "lint": "eslint .",
-    "lint:markdown": "markdownlint **/*.md --ignore node_modules"
+    "lint:markdown": "markdownlint **/*.md --ignore node_modules",
+    "export": "node src/export.js"
   },
   "dependencies": {
     "axios": "^0.25.0",

--- a/src/export.js
+++ b/src/export.js
@@ -1,0 +1,21 @@
+const { writeFileSync } = require('fs');
+const process = require('process');
+const { listJSFiles } = require('./utilities/bot-fs');
+
+const COMMANDS_FILE = 'commands.json';
+
+require('dotenv').config();
+
+const commands = listJSFiles('commands').map((command) => {
+  const { keyword, aliases, description } = command;
+  return {
+    keyword,
+    aliases,
+    description,
+  };
+});
+
+const indent = process.argv.includes('-pretty') ? 2 : 0;
+writeFileSync(COMMANDS_FILE, JSON.stringify(commands, null, indent), {
+  encoding: 'utf-8',
+});


### PR DESCRIPTION
> Requer o merge do PR #247 

Criando forma de exportar todos os comandos (e alias) existente no bot.

```sh
npm run export                       # para exportar os comandos em um JSON "minificado"
npm run export -- -pretty            # para exportar o JSON formatado, indentado.
```
