### PR TITLE
Skippando consulta de tweet se variáveis não estiverem definidas

### DIFF
--- a/src/commands/rt.js
+++ b/src/commands/rt.js
@@ -1,10 +1,19 @@
 const { client } = require('../core/twitch_client');
+const { isTwitterEnabled } = require('../core/twitter_client');
 const { getTodaysLiveAnnouncement } = require('../utilities/twitter/api');
 const { format } = require('../utilities/twitter/formatter');
 
 module.exports = {
   keyword: 'rt',
   execute: async ({ channel }) => {
+    if (!isTwitterEnabled()) {
+      console.info(`
+        Configuração incorreta dos tokens do Twitter.
+        Ignorando ação do comando !rt.
+      `);
+      return;
+    }
+
     const tweet = await getTodaysLiveAnnouncement();
     if (tweet) {
       const url = format.tweetURL(tweet.id);

--- a/src/core/twitter_client.js
+++ b/src/core/twitter_client.js
@@ -7,4 +7,13 @@ const client = new Twitter({
   access_token_secret: process.env.TW_ACCESS_TOKEN_SECRET,
 });
 
-module.exports = { client };
+function isTwitterEnabled() {
+  return (
+    process.env.TW_CONSUMER_KEY &&
+    process.env.TW_CONSUMER_SECRET &&
+    process.env.TW_ACCESS_TOKEN_KEY &&
+    process.env.TW_ACCESS_TOKEN_SECRET
+  );
+}
+
+module.exports = { client, isTwitterEnabled };

--- a/src/loops/retweet.js
+++ b/src/loops/retweet.js
@@ -4,7 +4,7 @@ const { getTodaysLiveAnnouncement } = require('../utilities/twitter/api');
 const { format } = require('../utilities/twitter/formatter');
 
 module.exports = {
-  interval: 5000, // 10min
+  interval: 600000, // 10min
   async execute() {
     if (!isTwitterEnabled()) {
       console.info(`

--- a/src/loops/retweet.js
+++ b/src/loops/retweet.js
@@ -1,10 +1,19 @@
 const { client } = require('../core/twitch_client');
+const { isTwitterEnabled } = require('../core/twitter_client');
 const { getTodaysLiveAnnouncement } = require('../utilities/twitter/api');
 const { format } = require('../utilities/twitter/formatter');
 
 module.exports = {
-  interval: 600000, // 10min
+  interval: 5000, // 10min
   async execute() {
+    if (!isTwitterEnabled()) {
+      console.info(`
+        Configuração incorreta dos tokens do Twitter.
+        Ignorando mensagem solicitando o retweet da live.
+      `);
+      return;
+    }
+
     const tweet = await getTodaysLiveAnnouncement();
     if (tweet) {
       const url = format.tweetURL(tweet.id);


### PR DESCRIPTION
Atualmente, se executar o bot sem configurar os tokens do Twitter, ocorre o seguinte erro:

```
throw new TwitterError_1.default(`${body.title}: ${error.message}`, body.type, body.detail);
              ^

TwitterError: undefined: Unable to verify your credentials
    at createBearerToken (C:\Users\pandadomalbot\node_modules\twitter-v2\build\Credentials.js:84:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Credentials.authorizationHeader (C:\Users\pandadomalbot\node_modules\twitter-v2\build\Credentials.js:167:13)
    at async Twitter.get (C:\Users\pandadomalbot\node_modules\twitter-v2\build\twitter.js:42:32)
    at async getTodaysLiveAnnouncement (C:\Users\pandadomalbot\src\utilities\twitter\api.js:13:20)
    at async Timeout.execute [as _onTimeout] (C:\Users\pandadomalbot\src\loops\retweet.js:8:19)
```

Isso acontece no uso do comando `!rt` e no lembre de retweet que ocorre há cada 10min.

Esse PR faz uma tratativa para "skippar" o uso dos comandos caso as variáveis do Twitter não estejam especificadas. Ex:
```
[09:56] info: [#rn4n] <rn4n>: !rt

        Configuração incorreta dos tokens do Twitter.
        Ignorando ação do comando !rt.
```

Também criei a issue #250 para explicar como obter e configurar os tokens do Twitter.

