### PR TITLE
Migrando "padrão"

### DIFF
--- a/src/autoreply/padrao.js
+++ b/src/autoreply/padrao.js
@@ -1,0 +1,17 @@
+let messages = [];
+
+const REPLY_AFTER = 2; // Responder após quantas mensagens iguais.
+
+function execute({ message }) {
+  messages.push(message);
+  if (messages.length === REPLY_AFTER && new Set(messages).size === 1) {
+    messages = [];
+    return message;
+  }
+  return null;
+}
+
+module.exports = {
+  patterns: [/^(.*?)$/],
+  execute,
+};

--- a/src/events/chat.js
+++ b/src/events/chat.js
@@ -41,15 +41,15 @@ function handleAutoReply(channel, context, message) {
       const matches = message.match(pattern);
 
       if (matches) {
-        client.say(
+        const result = item.execute({
           channel,
-          item.execute({
-            channel,
-            context,
-            message,
-            matches,
-          }),
-        );
+          context,
+          message,
+          matches,
+        });
+        if (result && typeof result === 'string') {
+          client.say(channel, result);
+        }
         break;
       }
     }


### PR DESCRIPTION
closes #217 

Migrando a feature de padrão:

<kbd>![image](https://user-images.githubusercontent.com/3982052/154503254-3546f27a-8717-4536-8f8c-08b74ac6c384.png)</kbd>

Na implementação anterior, dado que o bot respondesse um padrão, ele nunca mais o respondia até que a palavra fosse substituída, ex:
<kbd>![image](https://user-images.githubusercontent.com/3982052/154503620-ac8c3d45-c8ce-4894-9457-5255fb389424.png)</kbd>

Mudei para, sempre que houver uma quantidade "X" (no caso 2) de mensagens iguais, o bot responda igualmente também:
<kbd>![image](https://user-images.githubusercontent.com/3982052/154503763-8de1affb-1187-4d4a-9cdc-43a5bcb5cbe1.png)</kbd>

**Problemas conhecidos:**
Assim como na versão anterior, se houver uma alta quantidade de mensagens, o bot pode ficar "perdido" e a ordem das respostas podem ficar bugadas. É semelhante ao problema que ocorria quando tinham muitas mensagens que alteravam o arquivo de pontos dos usuários. Esse problema pode ser resolvido com uso de fila futuramente, se necessário. Exemplo do problema:

<kbd>![image](https://user-images.githubusercontent.com/3982052/154505069-fa019538-e410-4baa-910c-4e7c9ff947d3.png)</kbd>
