### PR TITLE
Corrigindo padrão

### DIFF
--- a/src/autoreply/padrao.js
+++ b/src/autoreply/padrao.js
@@ -4,9 +4,13 @@ const REPLY_AFTER = 2; // Responder após quantas mensagens iguais.
 
 function execute({ message }) {
   messages.push(message);
-  if (messages.length === REPLY_AFTER && new Set(messages).size === 1) {
-    messages = [];
-    return message;
+
+  if (messages.length === REPLY_AFTER) {
+    if (new Set(messages).size === 1) {
+      messages = [];
+      return message;
+    }
+    messages.shift();
   }
   return null;
 }


### PR DESCRIPTION
Há um problema na implementação da issue #217. O Array de últimas mensagens só está sendo "limpo" quando atinge a quantidade para considerar um padrão (no caso, 2 mensagens iguais). Se, entre essas mensagens for inserido outro texto, a verificação é desconsiderada e o Array só vai incluindo novos elementos. Como a verificação só ocorre quando seu tamanho é 2 e esse valor foi ultra passado faz tempo, a verificação será desconsiderada e o bot nunca irá responder com o padrão. Ex:

<kbd>![image](https://user-images.githubusercontent.com/3982052/154773064-38a7f57a-23d3-4d6a-bc79-98233348fc5b.png)</kbd>

Esse PR corrige esse problema, ficando:

<kbd>![image](https://user-images.githubusercontent.com/3982052/154773108-d2fc47e8-bf3f-49c5-a1cb-10fdb8f20aa4.png)</kbd>