### PR TITLE
Retornando `defaultValue` quando arquivo existir mas for vazio

### DIFF
--- a/src/utilities/data-file.js
+++ b/src/utilities/data-file.js
@@ -26,7 +26,10 @@ function read(file, defaultValue = {}) {
     return defaultValue;
   }
 
-  const content = readFileSync(path, { encoding: 'utf-8' }) || {};
+  const content = readFileSync(path, { encoding: 'utf-8' });
+
+  if (!content) return defaultValue;
+
   const json = JSON.parse(content);
   if (Object.keys(json).length === 0) {
     return defaultValue;


### PR DESCRIPTION
Ocorre um erro quando o arquivo existe mas está vazio. Deve ser retornado o valor de `defaultValue` especificado na função.

```none
[17:03] info: [#rn4n] <rn4n>: !rank
undefined:1
[object Object]
 ^

SyntaxError: Unexpected token o in JSON at position 1
    at JSON.parse (<anonymous>)
```