### PR TITLE
Movendo verificação de uso do comando e contador de uso

### DIFF
--- a/src/commands/rank.js
+++ b/src/commands/rank.js
@@ -9,13 +9,13 @@ const PODIUM = 3; // Quantos usuários no podium.
  * @returns {Array} lista de usuários.
  */
 async function ranked() {
-  const rankedUsers = await people(null);
+  const rankedUsers = await people();
   rankedUsers.sort((personA, personB) => {
-    if (personA.points < personB.points) return -1;
-    if (personB.points > personA.points) return 1;
+    if (personA.points > personB.points) return -1;
+    if (personB.points < personA.points) return 1;
     return 0;
   });
-  return rankedUsers.reverse();
+  return rankedUsers;
 }
 
 module.exports = {

--- a/src/models/person.js
+++ b/src/models/person.js
@@ -1,3 +1,5 @@
+const { isToday } = require('../utilities/date-time');
+
 class Person {
   /**
    * Representa um usuário do chat.
@@ -18,15 +20,53 @@ class Person {
 
   /**
    * Incrementa a quantidade de uso de um comando.
-   * @param {String} command chave para identificar o comando.
+   * @param {String} key chave para identificar o comando.
    */
-  incrementCommandUsage(command) {
-    const usage = {
-      counter: (this.usage[command]?.counter || 0) + 1,
-      lastuse: new Date().toLocaleDateString('pt-BR'),
-    };
+  incrementCommandUsage(key) {
+    const usage = this.usage[key] || {};
 
-    this.usage = { ...this.usage, [command]: usage };
+    this.usage = {
+      ...this.usage,
+      [key]: {
+        ...usage,
+        counter: (this.usage[key]?.counter || 0) + 1,
+      },
+    };
+  }
+
+  /**
+   * Define a última data de uso do comando para hoje.
+   *
+   * @param {String} key identificador do comando.
+   */
+  setLastCommandUsageForToday(key) {
+    const usage = this.usage[key] || {};
+
+    this.usage = {
+      ...this.usage,
+      [key]: {
+        ...usage,
+        lastuse: new Date().toLocaleDateString('pt-BR'),
+      },
+    };
+  }
+
+  /**
+   * Verifica se o usuário já utilizou o comando hoje.
+   *
+   * @param {String} key identificador do comando.
+   * @returns {Boolean} true, indicando que o usuário já utilizou o comando hoje.
+   * Do contrário false é retornado.
+   */
+  haveUsedTheCommandToday(key) {
+    const lastUsage = this.usage[key]?.lastuse || null;
+
+    if (!lastUsage) return false;
+
+    const parts = lastUsage.split('/');
+
+    const date = new Date(parts[2], parts[1] - 1, parts[0]);
+    return isToday(date);
   }
 
   /**

--- a/src/queues/people.js
+++ b/src/queues/people.js
@@ -10,7 +10,8 @@ async function worker({ username, callback }) {
   let content = read(FILE_NAME, []);
 
   if (!username) {
-    return content;
+    const users = content.map((data) => Person.fromJSON(data));
+    return users;
   }
 
   let born = false;


### PR DESCRIPTION
Movendo a responsabilidades (de incrementar o uso dos comandos e a verificação se o usuário já utilizou o comando no dia) para a classe `Person`. Requisito para resolver outras issues que verificam a data de uso do comando (ex: #234). Agora pode-se incrementar a quantidade de vezes que uma pessoa usou um comando, ex:

```js
// Aumenta +1 na conta de usos do comando !apostalev
await people('rn4n', person => {
   person.incrementCommandUsage('apostalev');
   return person;
});
```

E para verificar se o usuário já utilizou um determinado comando hoje, ex:

```js
await people('rn4n', person => {
   if(person.haveUsedTheCommandToday('apostalev')){
      // rn4n já utilizou o comando !apostalev hoje.
   }
});
```