### PR TITLE
Desconsiderando comandos ao contabilizar as mensagens para formar padrão

### DIFF
--- a/src/autoreply/padrao.js
+++ b/src/autoreply/padrao.js
@@ -1,8 +1,16 @@
+const { commands } = require('../utilities/commands');
+
 let messages = [];
 
 const REPLY_AFTER = 2; // Responder após quantas mensagens iguais.
+const commandsKeys = commands(true);
 
 function execute({ message }) {
+  if (commandsKeys.includes(message)) {
+    // Ignora comandos.
+    return null;
+  }
+
   messages.push(message);
 
   if (messages.length === REPLY_AFTER) {

--- a/src/commands/comandos.js
+++ b/src/commands/comandos.js
@@ -1,21 +1,9 @@
 const { client } = require('../core/twitch_client');
-const { listJSFiles } = require('../utilities/bot-fs');
-
-const getCommandKeys = (alias) => {
-  const keys = listJSFiles('commands').map((item) => {
-    let command = `${process.env.PREFIX}${item.keyword}`;
-    if (alias && item.aliases?.length > 0) {
-      command += `(${item.aliases?.join(',')})`;
-    }
-    return command;
-  });
-
-  return keys;
-};
+const { commandsAsText } = require('../utilities/commands');
 
 const execute = ({ argument, channel }) => {
-  const keys = getCommandKeys(argument && argument === 'alias');
-  client.say(channel, `Comandos disponíveis: ${keys.sort().join(', ')}.`);
+  const commands = commandsAsText(argument && argument === 'alias');
+  client.say(channel, `Comandos disponíveis: ${commands}.`);
 };
 
 module.exports = {

--- a/src/events/chat.js
+++ b/src/events/chat.js
@@ -1,9 +1,10 @@
 const { client } = require('../core/twitch_client');
 const { listJSFiles } = require('../utilities/bot-fs');
+const { listCommands } = require('../utilities/commands');
 
 const regex = new RegExp(`^${process.env.PREFIX}([a-zA-Z0-9]+)(?:\\W+)?(.*)?`);
-const commands = listJSFiles('commands');
 const autoReply = listJSFiles('autoreply');
+const commands = listCommands();
 
 function handleBotCommand(channel, context, message) {
   const command = message.match(regex);

--- a/src/export.js
+++ b/src/export.js
@@ -1,12 +1,12 @@
 const { writeFileSync } = require('fs');
 const process = require('process');
-const { listJSFiles } = require('./utilities/bot-fs');
+const { listCommands } = require('./utilities/commands');
 
 const COMMANDS_FILE = 'commands.json';
 
 require('dotenv').config();
 
-const commands = listJSFiles('commands').map((command) => {
+const commands = listCommands().map((command) => {
   const { keyword, aliases, description } = command;
   return {
     keyword,

--- a/src/utilities/commands.js
+++ b/src/utilities/commands.js
@@ -1,0 +1,61 @@
+const { listJSFiles } = require('./bot-fs');
+
+/**
+ * Obtém a lista de comandos disponíveis.
+ *
+ * @returns <{
+ *    keyword: string,
+ *    aliases: string[],
+ *    execute: Function
+ * }[]>
+ */
+function listCommands() {
+  const files = listJSFiles('commands');
+  return files.map((file) => {
+    const { keyword, aliases, execute } = file;
+    return { keyword, aliases, execute };
+  });
+}
+
+/**
+ * Obtém a listagem de todos os comandos e aliases.
+ *
+ * @param {Boolean} includePrefix se deve ser incluído o prefixo de comandos.
+ */
+function commands(includePrefix = false) {
+  const all = listCommands().reduce((acc, command) => {
+    if (command.aliases) {
+      acc = [...acc, ...command.aliases];
+    }
+    acc = [...acc, command.keyword];
+    return acc;
+  }, []);
+
+  if (includePrefix) {
+    return all.map((command) => `${process.env.PREFIX}${command}`);
+  }
+
+  return all;
+}
+
+/**
+ * Obtém todos os comandos disponíveis (como texto).
+ *
+ * @param {Boolean} alias se deve ser incluído os aliases.
+ */
+function commandsAsText(alias = false) {
+  const keys = listCommands().map((item) => {
+    let command = `${process.env.PREFIX}${item.keyword}`;
+    if (alias && item.aliases?.length > 0) {
+      command += `(${item.aliases?.join(',')})`;
+    }
+    return command;
+  });
+  return keys.sort().join(', ');
+}
+
+module.exports = {
+  commands,
+  listCommands,
+  commandsAsText,
+};


### PR DESCRIPTION
closes #268

- Criado um arquivo para centralizar tudo que é relacionado a listagem de comandos disponíveis no bot;
- Alterado o comportamento do "padrão" para ignorar mensagens que forem comando:

**Antes:**
<kbd>
![image](https://user-images.githubusercontent.com/3982052/158118878-5b7058e5-ae0e-4659-b4a2-4cfc43685fec.png)
</kbd>

**Agora:**
<kbd>
![image](https://user-images.githubusercontent.com/3982052/158118947-3b6e6a48-679b-4802-a4ea-32f44d85d783.png)
</kbd>