### PR TITLE
Criando comando `followage`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ USERNAME=
 PASSWORD=
 CHANNEL=levxyca
 
+# Twitch API
+API_ENDPOINT=https://api.twitch.tv/helix
+AUTH_ENDPOINT=https://id.twitch.tv/oauth2
+CLIENT_ID=
+CLIENT_SECRET=
+
 # Twitter
 TW_USERNAME=levxyca
 TW_TWEET_ANNOUNCE_REGEX=live\W+on\W+⭐

--- a/.github/docs/como-contribuir.md
+++ b/.github/docs/como-contribuir.md
@@ -47,6 +47,23 @@ Você pode utilizar a conta do seu canal mesmo, caso não tenha uma conta espec�
 - Em seguida, acesse [este serviço][5] e autorize o acesso à sua conta da Twitch
 - Depois de autorizado, guarde o token exibido.
 
+### Client ID/Secret
+
+Visto que também utilizamos a API da Twitch para obter algumas informações, é necessário que você
+registre uma aplicação no [console de desenvolvimento da Twitch][8]
+para obter um _client ID_ e um _client secret_. Para isto:
+
+- Acesse o [console][8] e clique em **Registre seu aplicativo**;
+- Em **Nome**, insira qualquer valor para identificar esta aplicação -
+_se preferir, pode ser o mesmo nome de usuário do bot_;
+- Em **URLs de redirecionamento OAuth**, pode utilizar o valor `http//localhost`. Isto não será importante
+visto que utilizamos o [_credentials flow_](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-client-credentials-flow).
+- Em **Categoria**, pode selecionar o valor "Chat Bot";
+- Clique em **Criar**.
+- Na tela seguinte, você terá acesso ao _client ID_ (**ID do cliente**) e _client secret_
+(**Segredo do cliente**), insira-os no arquivo de de variáveis de ambiente substituindo as chaves
+`CLIENT_ID` e `CLIENT_SECRET` respectivamente.
+
 ## Executando
 
 Você pode definir todas as variáveis de ambiente especificadas no arquivo [.env.example][4],
@@ -97,3 +114,4 @@ info: Joined :levxyca
 [5]: https://twitchapps.com/tmi/
 [6]: https://github.com/levxyca/pandadomalbot/issues
 [7]: https://dev.to/levxyca/pt-br-github-para-leigos-4i7j
+[8]: https://dev.twitch.tv/console/apps

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^0.26.1",
         "dotenv": "^16.0.0",
         "fastq": "^1.13.0",
+        "luxon": "^2.3.1",
         "tmi.js": "^1.8.5",
         "twitter-v2": "github:edsu/twitter-v2"
       },
@@ -1915,6 +1916,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.1.tgz",
+      "integrity": "sha512-I8vnjOmhXsMSlNMZlMkSOvgrxKJl0uOsEzdGgGNZuZPaS9KlefpE9KV95QFftlJSC+1UyCC9/I69R02cz/zcCA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -4548,6 +4557,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.1.tgz",
+      "integrity": "sha512-I8vnjOmhXsMSlNMZlMkSOvgrxKJl0uOsEzdGgGNZuZPaS9KlefpE9KV95QFftlJSC+1UyCC9/I69R02cz/zcCA=="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "axios": "^0.26.1",
     "dotenv": "^16.0.0",
     "fastq": "^1.13.0",
+    "luxon": "^2.3.1",
     "tmi.js": "^1.8.5",
     "twitter-v2": "github:edsu/twitter-v2"
   },

--- a/src/commands/fun/followage.js
+++ b/src/commands/fun/followage.js
@@ -1,7 +1,27 @@
 /* eslint-disable camelcase */
 const api = require('../../core/twitch_api');
 const { client } = require('../../core/twitch_client');
-const { fromNow, dateToString } = require('../../utilities/date-time');
+const { diff } = require('../../utilities/date-time');
+
+function format(years, months, days) {
+  const parts = [];
+  if (years && years > 0) {
+    parts.push(`${years} ano${years === 1 ? '' : 's'}`);
+  }
+  if (months && months > 0) {
+    parts.push(`${months} mese${months === 1 ? '' : 's'}`);
+  }
+  if (days && days > 0) {
+    parts.push(`${days} dia${days === 1 ? '' : 's'}`);
+  }
+
+  if (parts.length === 1) {
+    return parts[0];
+  }
+
+  const spllited = parts.splice(0, parts.length - 1);
+  return `${spllited.join(', ')} e ${parts[parts.length - 1]}`;
+}
 
 module.exports = {
   keyword: 'followage',
@@ -16,11 +36,10 @@ module.exports = {
 
     if (follow) {
       const { from_login, to_login, followed_at } = follow;
-      const date = new Date(followed_at);
+      const { years, months, days } = diff(new Date(followed_at));
+      const duration = format(years, months, days);
 
-      message = `${from_login} está seguindo ${to_login} desde ${dateToString(
-        date,
-      )}, ${fromNow(date)}.`;
+      message = `${from_login} está seguindo ${to_login} há ${duration}.`;
     } else {
       message = `${context.username} não está seguindo ${process.env.CHANNEL}.`;
     }

--- a/src/commands/fun/followage.js
+++ b/src/commands/fun/followage.js
@@ -1,0 +1,30 @@
+/* eslint-disable camelcase */
+const api = require('../../core/twitch_api');
+const { client } = require('../../core/twitch_client');
+const { fromNow, dateToString } = require('../../utilities/date-time');
+
+module.exports = {
+  keyword: 'followage',
+  execute: async ({ context, channel }) => {
+    if (api.me === null) {
+      await api.fetchCurrentUser();
+    }
+
+    const follow = await api.follow(context['user-id'], api.me.id);
+
+    let message;
+
+    if (follow) {
+      const { from_login, to_login, followed_at } = follow;
+      const date = new Date(followed_at);
+
+      message = `${from_login} está seguindo ${to_login} desde ${dateToString(
+        date,
+      )}, ${fromNow(date)}.`;
+    } else {
+      message = `${context.username} não está seguindo ${process.env.CHANNEL}.`;
+    }
+
+    await client.say(channel, message);
+  },
+};

--- a/src/core/twitch_api.js
+++ b/src/core/twitch_api.js
@@ -1,0 +1,101 @@
+const axios = require('axios').default;
+
+class TwitchAPI {
+  constructor() {
+    this.token = null;
+    this.url = process.env.API_ENDPOINT;
+    this.expiration = 4802369 / 2;
+    this.expiresIn = 0;
+    this.currentUser = null;
+  }
+
+  get me() {
+    return this.currentUser;
+  }
+
+  async #authorization() {
+    const query = new URLSearchParams({
+      client_id: process.env.CLIENT_ID,
+      client_secret: process.env.CLIENT_SECRET,
+      grant_type: 'client_credentials',
+      scopes: '',
+    });
+
+    const response = await axios.post(
+      `${process.env.AUTH_ENDPOINT}/token?${query}`,
+    );
+    if (response.status === 200) {
+      this.token = response.data.access_token;
+      this.expiresIn = response.data.expires_in;
+      return true;
+    }
+    return false;
+  }
+
+  async #validate() {
+    if (this.token === null) {
+      if (!(await this.#authorization())) {
+        throw new Error('Falha ao se autenticar pela API da Twitch.');
+      }
+    }
+
+    if (this.expiresIn < this.expiration) {
+      if (!(await this.#authorization())) {
+        throw new Error('Falha ao se autenticar pela API da Twitch.');
+      }
+    }
+    return true;
+  }
+
+  async fetchCurrentUser() {
+    const user = await this.user(process.env.CHANNEL);
+    if (user) {
+      this.currentUser = user;
+    }
+  }
+
+  /**
+   * Obtém os dados de um usuário pelo seu login.
+   *
+   * @param {String} username nome de usuário.
+   */
+  async user(username) {
+    if (await this.#validate()) {
+      const query = `login=${username}`;
+      const response = await axios.get(`${this.url}/users?${query}`, {
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          'Client-Id': process.env.CLIENT_ID,
+        },
+      });
+      if (response.status === 200) {
+        return response.data.data[0];
+      }
+      return null;
+    }
+    throw new Error('Falha ao obter o usuário pela API.');
+  }
+
+  async follow(from, to) {
+    if (await this.#validate()) {
+      const response = await axios.get(
+        `${this.url}/users/follows?to_id=${to}&from_id=${from}`,
+        {
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+            'Client-Id': process.env.CLIENT_ID,
+          },
+        },
+      );
+      if (response.status === 200 && response.data.total === 1) {
+        return response.data.data[0];
+      }
+      return null;
+    }
+    throw new Error('Falha ao obter os dados de follow pela API.');
+  }
+}
+
+const api = new TwitchAPI();
+
+module.exports = api;

--- a/src/core/twitch_api.js
+++ b/src/core/twitch_api.js
@@ -9,6 +9,11 @@ class TwitchAPI {
     this.currentUser = null;
   }
 
+  /**
+   * Obtém os informações do usuário do canal.
+   *
+   * PS: execute o método TwitchAPI#fetchCurrentUser antes de acessar esta propriedade.
+   */
   get me() {
     return this.currentUser;
   }
@@ -47,6 +52,9 @@ class TwitchAPI {
     return true;
   }
 
+  /**
+   * Obtém os dados do usuário do canal.
+   */
   async fetchCurrentUser() {
     const user = await this.user(process.env.CHANNEL);
     if (user) {
@@ -58,6 +66,19 @@ class TwitchAPI {
    * Obtém os dados de um usuário pelo seu login.
    *
    * @param {String} username nome de usuário.
+   *
+   * @returns {
+   *    "id": "141981764",
+   *    "login": "twitchdev",
+   *    "display_name": "TwitchDev",
+   *    "type": "",
+   *    "broadcaster_type": "partner",
+   *    "description": "Description example.",
+   *    "profile_image_url": "https://image-example.png",
+   *    "offline_image_url": "https://image-example.pngg",
+   *    "view_count": 5980557,
+   *    "created_at": "2016-12-14T20:32:28Z"
+   * }
    */
   async user(username) {
     if (await this.#validate()) {
@@ -76,6 +97,21 @@ class TwitchAPI {
     throw new Error('Falha ao obter o usuário pela API.');
   }
 
+  /**
+   * Obtém as informações sobre follow entre dois usuários.
+   *
+   * @param {string} from ID do usuário interessado (ex: quem usou o comando).
+   * @param {string} to ID do usuário alvo (ex: dono do canal).
+   *
+   * @returns {
+   *    "from_id": "171003792",
+   *    "from_login": "iiisutha067iii"
+   *    "from_name": "IIIsutha067III"
+   *    "to_id": "23161357",
+   *    "to_name": "LIRIK",
+   *    "followed_at": "2017-08-22T22:55:24Z"
+   * }
+   */
   async follow(from, to) {
     if (await this.#validate()) {
       const response = await axios.get(

--- a/src/utilities/date-time.js
+++ b/src/utilities/date-time.js
@@ -1,3 +1,18 @@
+const formatter = new Intl.RelativeTimeFormat('pt-BR', {
+  numeric: 'auto',
+  style: 'long',
+});
+
+const divisions = [
+  { amount: 60, name: 'seconds' },
+  { amount: 60, name: 'minutes' },
+  { amount: 24, name: 'hours' },
+  { amount: 7, name: 'days' },
+  { amount: 4.34524, name: 'weeks' },
+  { amount: 12, name: 'months' },
+  { amount: Number.POSITIVE_INFINITY, name: 'years' },
+];
+
 /**
  * Formata um objeto date para o formato especificado.
  *
@@ -28,8 +43,23 @@ const dateFromText = (text) => {
   return new Date(parts[2], parts[1] - 1, parts[0]);
 };
 
+function fromNow(date) {
+  let duration = (date - new Date()) / 1000;
+
+  let text = '';
+  divisions.forEach((division) => {
+    if (Math.abs(duration) < division.amount) {
+      text += formatter.format(Math.round(duration), division.name);
+    }
+    duration /= division.amount;
+  });
+
+  return text;
+}
+
 module.exports = {
   dateToString,
   isToday,
   dateFromText,
+  fromNow,
 };

--- a/src/utilities/date-time.js
+++ b/src/utilities/date-time.js
@@ -1,17 +1,4 @@
-const formatter = new Intl.RelativeTimeFormat('pt-BR', {
-  numeric: 'auto',
-  style: 'long',
-});
-
-const divisions = [
-  { amount: 60, name: 'seconds' },
-  { amount: 60, name: 'minutes' },
-  { amount: 24, name: 'hours' },
-  { amount: 7, name: 'days' },
-  { amount: 4.34524, name: 'weeks' },
-  { amount: 12, name: 'months' },
-  { amount: Number.POSITIVE_INFINITY, name: 'years' },
-];
+const { DateTime } = require('luxon');
 
 /**
  * Formata um objeto date para o formato especificado.
@@ -43,23 +30,25 @@ const dateFromText = (text) => {
   return new Date(parts[2], parts[1] - 1, parts[0]);
 };
 
-function fromNow(date) {
-  let duration = (date - new Date()) / 1000;
+/**
+ * Compara a quantidade de anos, meses e dias a partir de hoje.
+ * @param {Date} date data a ser comparada.
+ */
+function diff(date) {
+  const { years, months, days } = DateTime.now()
+    .diff(DateTime.fromJSDate(date), ['years', 'months', 'days'])
+    .toObject();
 
-  let text = '';
-  divisions.forEach((division) => {
-    if (Math.abs(duration) < division.amount) {
-      text += formatter.format(Math.round(duration), division.name);
-    }
-    duration /= division.amount;
-  });
-
-  return text;
+  return {
+    years: Math.round(years),
+    months: Math.round(months),
+    days: Math.round(days),
+  };
 }
 
 module.exports = {
   dateToString,
   isToday,
   dateFromText,
-  fromNow,
+  diff,
 };


### PR DESCRIPTION
closes #154
closes #195

## Pontos de atenção

- `CLIENT_ID` e `CLIENT_SECRET` precisam ser configurados, adicionei uma nota no arquivo de contribuição de como obter esses valores;
- Optei por utilizar o fluxo [`credentials_flow`](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-client-credentials-flow) - _(...) this also should be done only as a server-to-server request, never in client code (...)_. Isto que dizer que não vai ser necessária aquela autenticação do usuário sendo redirecionado para página de autorização da Twitch, porém este também é um pouco mais limitado. Não podemos realizar alterações em um usuário/canal, por exemplo, mudar o título da live (#151) mas poderemos acessar vários endpoints úteis. Inicialmente, não é solicitado nenhuma permissão específica, mas futuramente pode ser incluído [escopos](https://dev.twitch.tv/docs/authentication/#scopes) na nossa autenticação e ver como a API se comporta (permite ou não usar um recurso).
- PS: no primeiro uso do comando, pode-se levar um tempo maior para o bot responder visto que ocorre a autenticação. Execuções posteriores terão retorno quase imediato.

----

## seguindo há dias
![image](https://user-images.githubusercontent.com/3982052/158599752-bf35a811-54e5-4a70-8e56-ab24cfddcbbb.png)

## seguindo há meses
![image](https://user-images.githubusercontent.com/3982052/158599793-97ecb76c-76bb-44ef-822e-8676f529f4c2.png)

## seguindo há anos
![image](https://user-images.githubusercontent.com/3982052/158599833-3ce85691-983e-4940-91d2-1244c512d40b.png)
